### PR TITLE
🎨 Palette: Auto-resizing Chat Input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-05-22 - Focus Management in Root Portals
 **Learning:** Chat widgets injected at the document root detach from the natural focus order, trapping keyboard users or losing their place.
 **Action:** Implement manual focus restoration (using a ref to store activeElement) and global Escape key listeners for all root-injected overlays.
+
+## 2024-05-23 - Auto-resizing Textareas
+**Learning:** Fixed-height textareas in chat interfaces cause frustration. Auto-resizing logic via useEffect (reset to auto, then set to scrollHeight) works perfectly with React state.
+**Action:** Use this pattern for all multi-line inputs in chat widgets.

--- a/src/plugins/docusaurus-nova-ai/theme/NovaChat/index.tsx
+++ b/src/plugins/docusaurus-nova-ai/theme/NovaChat/index.tsx
@@ -136,6 +136,14 @@ export default function NovaChat(): React.JSX.Element | null {
     return () => window.removeEventListener('keydown', handleEsc);
   }, [isOpen]);
 
+  // 自动调整输入框高度
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.style.height = 'auto';
+      inputRef.current.style.height = `${inputRef.current.scrollHeight}px`;
+    }
+  }, [input]);
+
   const handleSend = useCallback(async () => {
     if (!input.trim() || isLoading) return;
 


### PR DESCRIPTION
🎨 Palette: Add auto-resizing to chat input

💡 **What:** Added auto-resizing behavior to the NovaChat input textarea.
🎯 **Why:** Users typing long messages previously had to scroll within a tiny 1-row box. Now the box expands gracefully as they type.
📸 **Before/After:** (Verified via Playwright screenshot)
  - Before: Fixed height, scrollbar appears.
  - After: Expands up to 120px height, then scrolls.
♿ **Accessibility:** No changes to ARIA attributes needed as this is a visual/interaction enhancement.

---
*PR created automatically by Jules for task [14768529659592027914](https://jules.google.com/task/14768529659592027914) started by @peterpanstechland*