### PR TITLE
🎨 Palette: Auto-resizing Chat Input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-05-22 - Focus Management in Root Portals
 **Learning:** Chat widgets injected at the document root detach from the natural focus order, trapping keyboard users or losing their place.
 **Action:** Implement manual focus restoration (using a ref to store activeElement) and global Escape key listeners for all root-injected overlays.
+
+## 2024-05-23 - Auto-resizing Chat Inputs
+**Learning:** Fixed-height textareas in chat widgets cause significant friction for users composing multi-line messages, leading to "scroll fatigue".
+**Action:** Always implement auto-resizing logic (min/max height constraints) for chat input fields to accommodate variable message lengths gracefully.

--- a/src/plugins/docusaurus-nova-ai/theme/NovaChat/index.tsx
+++ b/src/plugins/docusaurus-nova-ai/theme/NovaChat/index.tsx
@@ -111,6 +111,14 @@ export default function NovaChat(): React.JSX.Element | null {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
+  // 输入框高度自动调整
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.style.height = 'auto';
+      inputRef.current.style.height = `${inputRef.current.scrollHeight}px`;
+    }
+  }, [input]);
+
   // 聚焦管理
   useEffect(() => {
     if (isOpen) {


### PR DESCRIPTION
💡 **What:** Added auto-resizing capability to the NovaChat input field.
🎯 **Why:** Users typing long messages were stuck in a small 1-row input with a scrollbar, causing "scroll fatigue" and making it hard to review their message before sending.
📸 **Before/After:** Input now expands vertically (up to 120px) as text wraps.
♿ **Accessibility:** Improves usability for keyboard and screen reader users by ensuring content remains visible without manual scrolling where possible.

---
*PR created automatically by Jules for task [4810774947527600678](https://jules.google.com/task/4810774947527600678) started by @peterpanstechland*