### PR TITLE
🎨 Palette: Add auto-resizing textarea to NovaChat

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-22 - Focus Management in Root Portals
 **Learning:** Chat widgets injected at the document root detach from the natural focus order, trapping keyboard users or losing their place.
 **Action:** Implement manual focus restoration (using a ref to store activeElement) and global Escape key listeners for all root-injected overlays.
+## 2026-02-03 - Auto-resizing Inputs
+**Learning:** Fixed-height textareas in chat widgets frustrate users typing long messages.
+**Action:** Use a `useEffect` hook to reset height to 'auto' then set to `scrollHeight` on input change, bounded by CSS `max-height`.

--- a/src/plugins/docusaurus-nova-ai/theme/NovaChat/index.tsx
+++ b/src/plugins/docusaurus-nova-ai/theme/NovaChat/index.tsx
@@ -136,6 +136,14 @@ export default function NovaChat(): React.JSX.Element | null {
     return () => window.removeEventListener('keydown', handleEsc);
   }, [isOpen]);
 
+  // Textarea auto-resize
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.style.height = 'auto';
+      inputRef.current.style.height = `${inputRef.current.scrollHeight}px`;
+    }
+  }, [input]);
+
   const handleSend = useCallback(async () => {
     if (!input.trim() || isLoading) return;
 


### PR DESCRIPTION
💡 What: Added auto-resizing functionality to the chat input textarea.
🎯 Why: Users typing long messages could only see one line of text, making it difficult to review and edit their input.
📸 Before/After: Verified with Playwright that textarea grows from 44px to 120px (max-height) as content increases.
♿ Accessibility: Improves usability for keyboard and screen reader users by ensuring content remains visible and accessible without manual scrolling.

---
*PR created automatically by Jules for task [7521721200670104865](https://jules.google.com/task/7521721200670104865) started by @peterpanstechland*