### PR TITLE
🎨 Palette: Auto-resizing textarea & a11y fixes for NovaChat

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-05-22 - Focus Management in Root Portals
 **Learning:** Chat widgets injected at the document root detach from the natural focus order, trapping keyboard users or losing their place.
 **Action:** Implement manual focus restoration (using a ref to store activeElement) and global Escape key listeners for all root-injected overlays.
+
+## 2025-03-01 - Modal ARIA Semantics
+**Learning:** Adding `aria-modal="true"` to a non-modal dialog (like a chat widget) misleads screen readers if the background remains interactive.
+**Action:** Only use `aria-modal="true"` if you also implement a focus trap and background inertness. Otherwise, stick to `role="dialog"`.

--- a/src/plugins/docusaurus-nova-ai/theme/NovaChat/index.tsx
+++ b/src/plugins/docusaurus-nova-ai/theme/NovaChat/index.tsx
@@ -136,6 +136,15 @@ export default function NovaChat(): React.JSX.Element | null {
     return () => window.removeEventListener('keydown', handleEsc);
   }, [isOpen]);
 
+  // Auto-resize textarea
+  useEffect(() => {
+    const textarea = inputRef.current;
+    if (textarea) {
+      textarea.style.height = 'auto';
+      textarea.style.height = `${textarea.scrollHeight}px`;
+    }
+  }, [input]);
+
   const handleSend = useCallback(async () => {
     if (!input.trim() || isLoading) return;
 
@@ -190,12 +199,18 @@ export default function NovaChat(): React.JSX.Element | null {
     <div className={styles.container} data-position={position}>
       {/* 聊天窗口 */}
       {isOpen && (
-        <div className={styles.chatWindow}>
+        <div
+          className={styles.chatWindow}
+          role="dialog"
+          aria-labelledby="nova-chat-title"
+        >
           {/* 头部 */}
           <div className={styles.header}>
             <div className={styles.headerInfo}>
               <span className={styles.headerIcon}>⚡</span>
-              <span className={styles.headerTitle}>Nova AI 助手</span>
+              <span className={styles.headerTitle} id="nova-chat-title">
+                Nova AI 助手
+              </span>
               <span className={styles.statusDot} />
             </div>
             <button 


### PR DESCRIPTION
🎨 Palette: Auto-resizing textarea & a11y fixes for NovaChat

💡 **What:**
- Added auto-resizing capability to the NovaChat input field so it grows as the user types.
- Enhanced accessibility by adding semantic roles and labels to the chat window.

🎯 **Why:**
- Users often type long questions to AI assistants; a static single-row input is frustrating to edit.
- Screen readers previously saw the chat window as a generic div; now it is correctly identified as a dialog.

♿ **Accessibility:**
- Added `role="dialog"` to the chat container.
- Added `aria-labelledby` linked to the header title.
- Ensured `aria-modal` is NOT used, as this is a non-modal overlay allowing background interaction.

---
*PR created automatically by Jules for task [11227599363876922596](https://jules.google.com/task/11227599363876922596) started by @peterpanstechland*