### PR TITLE
🎨 Palette: Auto-expanding chat input & a11y polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-22 - Focus Management in Root Portals
 **Learning:** Chat widgets injected at the document root detach from the natural focus order, trapping keyboard users or losing their place.
 **Action:** Implement manual focus restoration (using a ref to store activeElement) and global Escape key listeners for all root-injected overlays.
+## 2025-05-22 - Auto-resizing Textareas
+**Learning:** For auto-expanding textareas, simply setting height to scrollHeight is insufficient because the element won't shrink when text is deleted.
+**Action:** Always reset height to 'auto' before calculating and setting the new scrollHeight to ensure the element can shrink correctly.

--- a/src/plugins/docusaurus-nova-ai/theme/NovaChat/index.tsx
+++ b/src/plugins/docusaurus-nova-ai/theme/NovaChat/index.tsx
@@ -111,6 +111,15 @@ export default function NovaChat(): React.JSX.Element | null {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
+  // 自动调整输入框高度
+  useEffect(() => {
+    const textarea = inputRef.current;
+    if (textarea) {
+      textarea.style.height = 'auto';
+      textarea.style.height = `${textarea.scrollHeight}px`;
+    }
+  }, [input]);
+
   // 聚焦管理
   useEffect(() => {
     if (isOpen) {
@@ -271,6 +280,7 @@ export default function NovaChat(): React.JSX.Element | null {
               placeholder={placeholder}
               rows={1}
               disabled={isLoading}
+              aria-label="输入消息"
             />
             <button
               className={styles.sendButton}


### PR DESCRIPTION
💡 **What:** Added auto-resizing capability to the NovaChat textarea and an ARIA label.
🎯 **Why:** Improves typing experience for long messages by preventing scroll-within-scroll, and adds a missing accessible name for screen readers.
📸 **Before/After:** Input now expands up to 120px height instead of staying at 1 row.
♿ **Accessibility:** Added `aria-label="输入消息"` to the textarea.

---
*PR created automatically by Jules for task [823429101611557339](https://jules.google.com/task/823429101611557339) started by @peterpanstechland*