### PR TITLE
🎨 Palette: Auto-resizing Chat Input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-22 - Focus Management in Root Portals
 **Learning:** Chat widgets injected at the document root detach from the natural focus order, trapping keyboard users or losing their place.
 **Action:** Implement manual focus restoration (using a ref to store activeElement) and global Escape key listeners for all root-injected overlays.
+## 2026-02-06 - Auto-Resizing Textareas
+**Learning:** For auto-growing textareas, simply setting height to scrollHeight prevents shrinking when text is deleted.
+**Action:** Always reset height to 'auto' immediately before setting it to scrollHeight in the resize effect.

--- a/src/plugins/docusaurus-nova-ai/theme/NovaChat/index.tsx
+++ b/src/plugins/docusaurus-nova-ai/theme/NovaChat/index.tsx
@@ -111,6 +111,15 @@ export default function NovaChat(): React.JSX.Element | null {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
+  // 自动调整输入框高度
+  useEffect(() => {
+    const textarea = inputRef.current;
+    if (textarea) {
+      textarea.style.height = 'auto';
+      textarea.style.height = `${textarea.scrollHeight}px`;
+    }
+  }, [input]);
+
   // 聚焦管理
   useEffect(() => {
     if (isOpen) {


### PR DESCRIPTION
🎨 Palette: Auto-resizing Chat Input

💡 What:
Added auto-resizing behavior to the chat input textarea. It now grows with content up to 120px and shrinks when text is deleted.

🎯 Why:
Users struggled to review long messages in the single-line input. This micro-interaction makes typing and reviewing messages much more comfortable.

📸 Before/After:
Before: Input stayed 1 row height (44px) regardless of content length.
After: Input grows smoothly to show full content (up to ~5 lines).

♿ Accessibility:
- No specific accessibility changes, but improved usability for all users.
- Maintained existing keyboard navigation and focus management.

---
*PR created automatically by Jules for task [4986547549134328214](https://jules.google.com/task/4986547549134328214) started by @peterpanstechland*